### PR TITLE
Added an sleep when rabbitmq starts

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 set -e
-
+sleep 10
 exec /usr/local/bin/docker-entrypoint.sh rabbitmq-server


### PR DESCRIPTION
A race condition could be reached when launching on rancher with multiple nodes. The configuration could not be refreshed when rabbitmq starts and it takes default one and then it does not join to the cluster.